### PR TITLE
fix: Different seed per processes

### DIFF
--- a/src/random.rs
+++ b/src/random.rs
@@ -1,3 +1,6 @@
+use core::convert::TryInto;
+
+use alloc::format;
 use rand_chacha::{rand_core::SeedableRng, ChaCha12Rng};
 use spin::{Lazy, Mutex};
 
@@ -9,6 +12,28 @@ pub(crate) fn global_rng() -> &'static Mutex<ChaCha12Rng> {
 }
 
 fn gen_seed() -> [u8; 32] {
-    // FIXME generate different seeds for each process
-    [0; 32]
+    let a0 = gen_rand_u64_mem_addr();
+    let a1 = a0 ^ a0.rotate_right(13);
+    let a2 = a1 ^ a1.rotate_right(17);
+    let a3 = a2 ^ a2.rotate_right(5);
+
+    let a0 = a0.to_le_bytes();
+    let a1 = a1.to_le_bytes();
+    let a2 = a2.to_le_bytes();
+    let a3 = a3.to_le_bytes();
+
+    [a0, a1, a2, a3]
+        .concat()
+        .try_into()
+        .expect("must be 32 bytes")
+}
+
+/// Poorly distributed numbers to use themselves as rand.
+/// Just use as seed.
+fn gen_rand_u64_mem_addr() -> u64 {
+    let x = 123;
+    let x_addr = &x as *const i32;
+    let x_addr_s = format!("{:p}", x_addr);
+    let x_addr_s = x_addr_s.trim_start_matches("0x");
+    u64::from_str_radix(x_addr_s, 16).expect("must be a hex string")
 }

--- a/tests/feat_serde_encrypt_public_key_different_cipher_from_same_plain.rs
+++ b/tests/feat_serde_encrypt_public_key_different_cipher_from_same_plain.rs
@@ -1,0 +1,39 @@
+//! Test if SerdeEncryptPublicKey emits different cipher-text for the same plain-text to avoid attacks such as statistical analysis of cipher-text.
+
+mod test_util;
+
+use serde::{Deserialize, Serialize};
+use serde_encrypt::{error::Error, traits::SerdeEncryptPublicKey};
+use test_util::serde_encrypt_public_key::*;
+
+#[test]
+fn test_serde_encrypt_public_key_in_a_process() -> Result<(), Error> {
+    keygen!(sender_combined_key, _x);
+
+    #[derive(PartialEq, Debug, Serialize, Deserialize)]
+    struct Message(String);
+    impl SerdeEncryptPublicKey for Message {}
+
+    type EncMessage = Vec<u8>;
+
+    let mut enc_msgs = Vec::<EncMessage>::new();
+    for _ in 0..100 {
+        let msg = Message("same message".into());
+        let encrypted = msg.encrypt(&sender_combined_key)?;
+        let enc_msg = encrypted.serialize();
+        enc_msgs.push(enc_msg);
+    }
+
+    for i in 0..100 {
+        let enc_msg_i = enc_msgs.get(i).unwrap();
+        for j in (i + 1)..100 {
+            let enc_msg_j = enc_msgs.get(j).unwrap();
+            assert_ne!(enc_msg_i, enc_msg_j);
+        }
+    }
+
+    Ok(())
+}
+
+// Difficult to test "separate processes produce different cipher-text".
+// Unit test in [random.rs](https://github.com/laysakura/serde-encrypt/blob/main/src/random.rs) assures it.

--- a/tests/feat_serde_encrypt_public_key_different_cipher_from_same_plain.rs
+++ b/tests/feat_serde_encrypt_public_key_different_cipher_from_same_plain.rs
@@ -35,5 +35,4 @@ fn test_serde_encrypt_public_key_in_a_process() -> Result<(), Error> {
     Ok(())
 }
 
-// Difficult to test "separate processes produce different cipher-text".
-// Unit test in [random.rs](https://github.com/laysakura/serde-encrypt/blob/main/src/random.rs) assures it.
+// TODO Test "separate processes produce different cipher-text".

--- a/tests/test_util/serde_encrypt_public_key/mod.rs
+++ b/tests/test_util/serde_encrypt_public_key/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use core::fmt;
 
 use serde::{de::DeserializeOwned, Serialize};


### PR DESCRIPTION
Ensured by println!() debug.
Writing test to launch 2 or more processes (to change local variable's address) is difficult.