### PR TITLE
Change SharedKey  from `private` to `pub`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ Then, you can serialize the `Message` into `Vec<u8>` in encrypted form.
     };
     let encrypted_message = msg.encrypt(&shared_key)?;
 
-    // Alternative: 
-    // let _: Vec<u8> = EncryptedMessage::serialize(encrypted_message);
     let serialized_encrypted_message: Vec<u8> = encrypted_message.serialize();
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,16 +73,22 @@ Then, you can serialize the `Message` into `Vec<u8>` in encrypted form.
         sender: "Alice".to_string(),
     };
     let encrypted_message = msg.encrypt(&shared_key)?;
-    let serialized_encrypted_message: Vec<u8> = encrypted_message.serialize()?;
+
+    // Alternative: 
+    // let _: Vec<u8> = EncryptedMessage::serialize(encrypted_message);
+    let serialized_encrypted_message: Vec<u8> = encrypted_message.serialize();
 ```
 
 After your peer gets the binary, they can decrypt and deserialize it to `Message`.
 
 ```rust
-    let shared_key = [0u8; 32];  // or your peer reads from filesystem?
+    // Alternative:
+    // let shared_key = SharedKey::from([0u8; 32]);
+    const shared_key: SharedKey = SharedKey([0u8; 32]); // or your peer reads from elsewhere.
+    
 
     let encrypted_message = EncryptedMessage::deserialize(serialized_encrypted_message)?;
-    let msg = Message::decrypt_owned(&encrypted_message, &shared_key)
+    let msg = Message::decrypt_owned(&encrypted_message, &shared_key);
 ```
 
 ### Further examples...

--- a/README.md
+++ b/README.md
@@ -66,24 +66,22 @@ impl SerdeEncryptSharedKey for Message {
 Then, you can serialize the `Message` into `Vec<u8>` in encrypted form.
 
 ```rust
-    let shared_key = [0u8; 32];  // or read from your filesystem?
+    // Alternative:
+    // const SHARED_KEY: SharedKey = SharedKey::new_const([0u8; 32]); 
+    let shared_key = SharedKey::new([0u8; 32]); // or your peer reads from elsewhere.
 
     let msg = Message {
         content: "I ❤️ you.".to_string(),
         sender: "Alice".to_string(),
     };
     let encrypted_message = msg.encrypt(&shared_key)?;
-
     let serialized_encrypted_message: Vec<u8> = encrypted_message.serialize();
 ```
 
 After your peer gets the binary, they can decrypt and deserialize it to `Message`.
 
 ```rust
-    // Alternative:
-    // let shared_key = SharedKey::from([0u8; 32]);
-    const shared_key: SharedKey = SharedKey([0u8; 32]); // or your peer reads from elsewhere.
-    
+    let shared_key = SharedKey::new([0u8; 32]);
 
     let encrypted_message = EncryptedMessage::deserialize(serialized_encrypted_message)?;
     let msg = Message::decrypt_owned(&encrypted_message, &shared_key);

--- a/serde-encrypt/src/shared_key.rs
+++ b/serde-encrypt/src/shared_key.rs
@@ -14,13 +14,13 @@ pub struct SharedKey([u8; 32]);
 
 impl SharedKey {
     /// Build SharedKey from static `[u8; 32]` data at compile time.
-    pub const fn new_const(data: &[u8; 32]) -> Self {
-        Self(*data)
+    pub const fn new_const(data: [u8; 32]) -> Self {
+        Self(data)
     }
 
     /// Build SharedKey from `[u8; 32]` data.
-    pub fn new(data: &[u8; 32]) -> Self {
-        Self(*data)
+    pub fn new(data: [u8; 32]) -> Self {
+        Self(data)
     }
 }
 
@@ -66,13 +66,12 @@ mod test {
         const SHAREDKEY_CONST_INTERNAL: SharedKey = SharedKey(STATIC_ARRAY);
 
         // Test `const fn new`, which build SharedKey in compile time
-        const SHARED_KEY_CONST: SharedKey = SharedKey::new_const(&STATIC_ARRAY);
+        const SHARED_KEY_CONST: SharedKey = SharedKey::new_const(STATIC_ARRAY);
 
         // Test `fn new`, which build SharedKey in runtime.
-        let shared_key = SharedKey::new(&runtime_array);
+        let shared_key = SharedKey::new(runtime_array);
 
         assert_eq!(shared_key, SHAREDKEY_CONST_INTERNAL);
         assert_eq!(SHARED_KEY_CONST, SHAREDKEY_CONST_INTERNAL);
     }
 }
-

--- a/serde-encrypt/src/shared_key.rs
+++ b/serde-encrypt/src/shared_key.rs
@@ -1,8 +1,8 @@
 //! serde-serializable shared key.
 
-use crate::{random::RngSingletonImpl, AsSharedKey};
 use serde::{Deserialize, Serialize};
 
+use crate::{AsSharedKey, random::RngSingletonImpl};
 use crate::traits::SerdeEncryptPublicKey;
 
 /// 32-byte key shared among sender and receiver secretly.
@@ -10,7 +10,13 @@ use crate::traits::SerdeEncryptPublicKey;
 /// It is a good practice to use [SerdeEncryptPublicKey](crate::traits::SerdeEncryptPublicKey)
 /// to exchange this shared key.
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
-pub struct SharedKey([u8; 32]);
+pub struct SharedKey(pub [u8; 32]);
+
+impl From<[u8; 32]> for SharedKey {
+    fn from(data: [u8; 32]) -> Self {
+        Self(data)
+    }
+}
 
 impl AsSharedKey for SharedKey {
     type R = RngSingletonImpl;
@@ -35,5 +41,22 @@ cfg_if::cfg_if! {
         impl SerdeEncryptPublicKey for SharedKey {
             type S = PostcardSerializer<Self>;
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn build_sharedkey_from_array() {
+        const STATIC_ARRAY: [u8; 32] = [1, 1, 4, 5, 1, 4,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+        const SHAREDKEY_CONST: SharedKey = SharedKey(STATIC_ARRAY);
+
+        let shared_key = SharedKey::from(STATIC_ARRAY);
+
+        assert_eq!(shared_key, SHAREDKEY_CONST);
     }
 }


### PR DESCRIPTION
Related compile error:
```text
error[E0423]: cannot initialize a tuple struct which contains private fields
  --> src/main.rs:94:34
   |
94 |     const SHAREDKEY: SharedKey = SharedKey([0u8; 32]);
```

by default, tuple like struct is private and cannot be automatically built from static array `[u8; 32]`

Also, add test casees and alter the readme to suit the changes.
