### PR TITLE
fix(lint): fix lint problesm from cargo clippy

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/serde-encrypt.iml" filepath="$PROJECT_DIR$/.idea/serde-encrypt.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/serde-encrypt.iml
+++ b/.idea/serde-encrypt.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/serde-encrypt-core/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/serde-encrypt-core/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/serde-encrypt/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/serde-encrypt/tests" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/serde-encrypt-core/src/key/combined_key.rs
+++ b/serde-encrypt-core/src/key/combined_key.rs
@@ -31,11 +31,11 @@ impl<'s, 'r> SenderCombinedKey<'s, 'r> {
     }
 
     pub(crate) fn sender_private_key(&self) -> &SenderPrivateKey {
-        &self.sender_private_key
+        self.sender_private_key
     }
 
     pub(crate) fn receiver_public_key(&self) -> &ReceiverPublicKey {
-        &self.receiver_public_key
+        self.receiver_public_key
     }
 }
 
@@ -61,10 +61,10 @@ impl<'s, 'r> ReceiverCombinedKey<'s, 'r> {
     }
 
     pub(crate) fn receiver_private_key(&self) -> &ReceiverPrivateKey {
-        &self.receiver_private_key
+        self.receiver_private_key
     }
 
     pub(crate) fn sender_public_key(&self) -> &SenderPublicKey {
-        &self.sender_public_key
+        self.sender_public_key
     }
 }

--- a/serde-encrypt/src/traits/serde_encrypt_public_key.rs
+++ b/serde-encrypt/src/traits/serde_encrypt_public_key.rs
@@ -50,7 +50,7 @@ pub trait SerdeEncryptPublicKey {
     where
         Self: Serialize,
     {
-        let serialized = Self::S::serialize(&self)?;
+        let serialized = Self::S::serialize(self)?;
         let plain_msg = PlainMessagePublicKey::new(serialized.into_vec());
         plain_msg.encrypt(combined_key)
     }

--- a/serde-encrypt/src/traits/serde_encrypt_shared_key.rs
+++ b/serde-encrypt/src/traits/serde_encrypt_shared_key.rs
@@ -56,7 +56,7 @@ pub trait SerdeEncryptSharedKey {
     where
         Self: Serialize,
     {
-        let serialized = Self::S::serialize(&self)?;
+        let serialized = Self::S::serialize(self)?;
         let plain_msg = PlainMessageSharedKey::new(serialized.into_vec());
         plain_msg.encrypt(shared_key)
     }

--- a/serde-encrypt/src/traits/serde_encrypt_shared_key_deterministic.rs
+++ b/serde-encrypt/src/traits/serde_encrypt_shared_key_deterministic.rs
@@ -49,7 +49,7 @@ pub trait SerdeEncryptSharedKeyDeterministic {
     where
         Self: Serialize,
     {
-        let serialized = Self::S::serialize(&self)?;
+        let serialized = Self::S::serialize(self)?;
         let plain_msg = PlainMessageSharedKeyDeterministic::new(serialized.into_vec());
         plain_msg.encrypt(shared_key)
     }

--- a/serde-encrypt/tests/example_serde_encrypt_public_key_struct_with_reference.rs
+++ b/serde-encrypt/tests/example_serde_encrypt_public_key_struct_with_reference.rs
@@ -43,7 +43,7 @@ fn bob_reads_secret_message(
 ) -> Result<(), Error> {
     let encrypted_message = EncryptedMessage::deserialize(encrypted_serialized)?;
 
-    let decrypted = Message::decrypt_ref(&encrypted_message, &combined_key)?;
+    let decrypted = Message::decrypt_ref(&encrypted_message, combined_key)?;
     let revealed_message = decrypted.deserialize()?;
 
     // Note that you cannot return `revealed_message` from this function

--- a/serde-encrypt/tests/example_serde_encrypt_shared_key_encryption_with_key_exchange.rs
+++ b/serde-encrypt/tests/example_serde_encrypt_shared_key_encryption_with_key_exchange.rs
@@ -45,7 +45,7 @@ fn alice_receives_shared_key(
     combined_key: &ReceiverCombinedKey,
 ) -> Result<SharedKey, Error> {
     let encrypted_shared_key = EncryptedMessage::deserialize(encrypted_serialized_shared_key)?;
-    SharedKey::decrypt_owned(&encrypted_shared_key, &combined_key)
+    SharedKey::decrypt_owned(&encrypted_shared_key, combined_key)
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -78,7 +78,7 @@ fn bob_reads_secret_message(
 ) -> Result<(), Error> {
     let encrypted_message = EncryptedMessage::deserialize(encrypted_serialized)?;
 
-    let decrypted = Message::decrypt_ref(&encrypted_message, &shared_key)?;
+    let decrypted = Message::decrypt_ref(&encrypted_message, shared_key)?;
     let revealed_message = decrypted.deserialize()?;
 
     // Note that you cannot return `revealed_message` from this function


### PR DESCRIPTION
Just fix lint problems, mostly remove the useless `&`s, as the clippy suggests.

Close #107 
