### PR TITLE
Update Cargo.toml

### DIFF
--- a/serde-encrypt/Cargo.toml
+++ b/serde-encrypt/Cargo.toml
@@ -26,7 +26,7 @@ cfg-if = "1.0"
 
 # Lazy static options
 once_cell = {version = "1.8", optional = true}
-spin = {version = "0.9", default-features = false, features = ["spin_mutex", "lazy"]}# default (available w/o std)
+spin = {version = "0.9.8", default-features = false, features = ["spin_mutex", "lazy"]}# default (available w/o std)
 
 [dev-dependencies]
 serde = {version = "1.0", default-features = false, features = ["derive", "alloc"]}# alloc for Vec, String


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)