### PR TITLE
Update dependencies and security margin

### DIFF
--- a/serde-encrypt-core/Cargo.toml
+++ b/serde-encrypt-core/Cargo.toml
@@ -3,17 +3,17 @@ authors = ["Sho Nakatani <lay.sakura@gmail.com>"]
 categories = ["no-std", "cryptography", "encoding"]
 description = "Encrypts all the Serialize"
 documentation = "https://docs.rs/serde-encrypt-core"
-edition = "2018"
+edition = "2021"
 keywords = ["libsodium", "xsalsa20poly1305", "x25519", "serde", "serde-encrypt"] # up to 5 keywords, each keyword should have <= 20 chars
 license = "MIT OR Apache-2.0"
 name = "serde-encrypt-core"
 readme = "../README.md"
 repository = "https://github.com/laysakura/serde-encrypt"
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies]
-chacha20poly1305 = {version = "0.8", default-features = false, features = ["alloc", "xchacha20poly1305"]}
-crypto_box = {version = "0.6"}
+chacha20poly1305 = {version = "0.10", default-features = false, features = ["alloc"]}
+crypto_box = {version = "0.9", features = ["chacha20"] }
 
 rand = {version = "0.8", default-features = false}
 rand_chacha = {version = "0.3", default-features = false}

--- a/serde-encrypt-core/src/encrypt/plain_message_public_key.rs
+++ b/serde-encrypt-core/src/encrypt/plain_message_public_key.rs
@@ -2,11 +2,7 @@
 
 use core::ops::DerefMut;
 
-use crate::{
-    error::Error,
-    key::combined_key::{ReceiverCombinedKey, SenderCombinedKey},
-    random::RngSingleton,
-};
+use crate::{error::Error, key::combined_key::{ReceiverCombinedKey, SenderCombinedKey}, random, random::RngSingleton};
 use alloc::vec::Vec;
 use chacha20poly1305::{aead::Payload, XNonce};
 use crypto_box::{aead::Aead, ChaChaBox};
@@ -80,7 +76,6 @@ pub trait PlainMessagePublicKeyCore {
 
     /// Generate random nonce which is large enough (24-byte) to rarely conflict.
     fn generate_nonce() -> XNonce {
-        let mut rng = Self::R::instance();
-        crypto_box::generate_nonce(rng.deref_mut())
+        random::generate_nonce(&mut Self::R::instance().deref_mut())
     }
 }

--- a/serde-encrypt-core/src/encrypt/plain_message_shared_key.rs
+++ b/serde-encrypt-core/src/encrypt/plain_message_shared_key.rs
@@ -10,7 +10,7 @@ use super::encrypted_message::EncryptedMessage;
 use crate::{error::Error, key::as_shared_key::AsSharedKey};
 use alloc::{format, vec::Vec};
 use chacha20poly1305::{XChaCha20Poly1305, XNonce};
-use crypto_box::aead::{Aead, NewAead};
+use crypto_box::aead::{Aead, KeyInit};
 
 /// Encrypt into EncryptedMessage
 fn encrypt<S>(

--- a/serde-encrypt-core/src/encrypt/plain_message_shared_key/shared_key_core.rs
+++ b/serde-encrypt-core/src/encrypt/plain_message_shared_key/shared_key_core.rs
@@ -6,6 +6,7 @@ use crate::{error::Error, key::as_shared_key::AsSharedKey};
 use alloc::vec::Vec;
 use chacha20poly1305::XNonce;
 use core::ops::DerefMut;
+use rand_chacha::rand_core::RngCore;
 
 use super::{decrypt, encrypt};
 
@@ -47,6 +48,8 @@ pub trait PlainMessageSharedKeyCore {
     /// Generate random nonce which is large enough (24-byte) to rarely conflict.
     fn generate_nonce() -> XNonce {
         let mut rng = Self::R::instance();
-        crypto_box::generate_nonce(rng.deref_mut())
+        let mut nonce = XNonce::default();
+        rng.deref_mut().fill_bytes(&mut nonce);
+        nonce
     }
 }

--- a/serde-encrypt-core/src/random.rs
+++ b/serde-encrypt-core/src/random.rs
@@ -1,14 +1,22 @@
 //! RNG abstract
 
 use core::ops::DerefMut;
+use chacha20poly1305::XNonce;
 
-use rand_chacha::ChaCha12Rng;
+use rand_chacha::ChaCha20Rng;
+use rand_chacha::rand_core::{CryptoRng, RngCore};
 
 /// RNG singleton
 pub trait RngSingleton {
-    /// &mut ChaCha12Rng
-    type D: DerefMut<Target = ChaCha12Rng>;
+    /// &mut ChaCha20Rng
+    type D: DerefMut<Target = ChaCha20Rng>;
 
     /// Singleton instance
     fn instance() -> Self::D;
+}
+
+pub(crate) fn generate_nonce<R: RngCore + CryptoRng>(rng: &mut R) -> XNonce {
+    let mut nonce = XNonce::default();
+    rng.fill_bytes(&mut nonce);
+    nonce
 }

--- a/serde-encrypt-core/tests/test_util/random/mod.rs
+++ b/serde-encrypt-core/tests/test_util/random/mod.rs
@@ -1,15 +1,15 @@
 use rand::SeedableRng;
-use rand_chacha::ChaCha12Rng;
+use rand_chacha::ChaCha20Rng;
 use serde_encrypt_core::random::RngSingleton;
 use spin::{Lazy, Mutex, MutexGuard};
 
-static GLOBAL_RNG: Lazy<Mutex<ChaCha12Rng>> =
-    Lazy::new(|| Mutex::new(ChaCha12Rng::from_seed([0u8; 32])));
+static GLOBAL_RNG: Lazy<Mutex<ChaCha20Rng>> =
+    Lazy::new(|| Mutex::new(ChaCha20Rng::from_seed([0u8; 32])));
 
 #[derive(Clone, Debug)]
 pub struct TestRngSingleton;
 impl RngSingleton for TestRngSingleton {
-    type D = MutexGuard<'static, ChaCha12Rng>;
+    type D = MutexGuard<'static, ChaCha20Rng>;
 
     fn instance() -> Self::D {
         GLOBAL_RNG.lock()

--- a/serde-encrypt/Cargo.toml
+++ b/serde-encrypt/Cargo.toml
@@ -3,21 +3,21 @@ authors = ["Sho Nakatani <lay.sakura@gmail.com>"]
 categories = ["no-std", "cryptography", "encoding"]
 description = "Encrypts all the Serialize"
 documentation = "https://docs.rs/serde-encrypt"
-edition = "2018"
+edition = "2021"
 keywords = ["libsodium", "xsalsa20poly1305", "x25519", "serde", "serde-encrypt"] # up to 5 keywords, each keyword should have <= 20 chars
 license = "MIT OR Apache-2.0"
 name = "serde-encrypt"
 readme = "../README.md"
 repository = "https://github.com/laysakura/serde-encrypt"
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies]
-serde-encrypt-core = {version = "0.7.0", path = "../serde-encrypt-core", default-features = false}
+serde-encrypt-core = {version = "0.8.0", path = "../serde-encrypt-core", default-features = false}
 
 bincode = {version = "1.3", optional = true}
-postcard = {version = "0.7", default-features = false, features = ["alloc"]}
+postcard = {version = "1.0", default-features = false, features = ["alloc"]}
 serde = {version = "1.0", default-features = false}
-serde_cbor = {version = "0.11", default-features = false, features = ["alloc"]}
+serde_cbor = { version = "0.11", default-features = false, features = ["alloc"] }
 
 rand_chacha = {version = "0.3", default-features = false}
 rand_core = {version = "0.6", default-features = false}

--- a/serde-encrypt/src/random.rs
+++ b/serde-encrypt/src/random.rs
@@ -6,18 +6,18 @@ use alloc::format;
 use core::convert::TryInto;
 
 use crate::{Lazy, Mutex, MutexGuard};
-use rand_chacha::ChaCha12Rng;
+use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
 use serde_encrypt_core::random::RngSingleton;
 
-static GLOBAL_RNG: Lazy<Mutex<ChaCha12Rng>> =
-    Lazy::new(|| Mutex::new(RngSingletonImpl::chacha12_rng()));
+static GLOBAL_RNG: Lazy<Mutex<ChaCha20Rng>> =
+    Lazy::new(|| Mutex::new(RngSingletonImpl::chacha20_rng()));
 
 /// RNG singleton implementation
 #[derive(Clone, Debug)]
 pub struct RngSingletonImpl;
 impl RngSingleton for RngSingletonImpl {
-    type D = MutexGuard<'static, ChaCha12Rng>;
+    type D = MutexGuard<'static, ChaCha20Rng>;
 
     #[cfg(feature = "std")]
     fn instance() -> Self::D {
@@ -32,13 +32,13 @@ impl RngSingleton for RngSingletonImpl {
 }
 impl RngSingletonImpl {
     #[cfg(feature = "std")]
-    fn chacha12_rng() -> ChaCha12Rng {
-        ChaCha12Rng::from_entropy()
+    fn chacha20_rng() -> ChaCha20Rng {
+        ChaCha20Rng::from_entropy()
     }
 
     #[cfg(not(feature = "std"))]
-    fn chacha12_rng() -> ChaCha12Rng {
-        ChaCha12Rng::from_seed(Self::gen_seed())
+    fn chacha20_rng() -> ChaCha20Rng {
+        ChaCha20Rng::from_seed(Self::gen_seed())
     }
 
     #[cfg(not(feature = "std"))]

--- a/serde-encrypt/src/shared_key.rs
+++ b/serde-encrypt/src/shared_key.rs
@@ -2,8 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{AsSharedKey, random::RngSingletonImpl};
 use crate::traits::SerdeEncryptPublicKey;
+use crate::{random::RngSingletonImpl, AsSharedKey};
 
 /// 32-byte key shared among sender and receiver secretly.
 ///
@@ -52,13 +52,15 @@ cfg_if::cfg_if! {
 
 #[cfg(test)]
 mod test {
-    use std::convert::TryInto;
     use super::*;
+    use std::convert::TryInto;
 
     #[test]
     fn build_sharedkey_from_array() {
-        const STATIC_ARRAY: [u8; 32] = [1, 1, 4, 5, 1, 4,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        const STATIC_ARRAY: [u8; 32] = [
+            1, 1, 4, 5, 1, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ];
 
         let runtime_array: [u8; 32] = Vec::from(STATIC_ARRAY).try_into().unwrap();
 


### PR DESCRIPTION
This updates the dependencies to secure versions since `crypto_box` 0.6 has a vulnerability.
This also updates from using Chacha12 to Chacha20 which has higher security margins and performance difference is negligible.