### PR TITLE
Updates outdated dependencies

### DIFF
--- a/serde-encrypt-core/Cargo.toml
+++ b/serde-encrypt-core/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/laysakura/serde-encrypt"
 version = "0.7.0"
 
 [dependencies]
-chacha20poly1305 = {version = "0.8", default-features = false, features = ["alloc", "xchacha20poly1305"]}
-crypto_box = {version = "0.6"}
+crypto_secretbox = {version = "0.1.1", default-features = false, features = ["chacha20", "alloc"]}
+crypto_box = {version = "0.9.1",  features = ["chacha20"]}
 
 rand = {version = "0.8", default-features = false}
 rand_chacha = {version = "0.3", default-features = false}
@@ -25,6 +25,6 @@ spin = {version = "0.9", default-features = false, features = ["spin_mutex", "la
 default = ["std"]
 
 std = [
-  "chacha20poly1305/std",
+  "crypto_secretbox/std",
   "rand_chacha/std",
 ]

--- a/serde-encrypt-core/src/encrypt/plain_message_public_key.rs
+++ b/serde-encrypt-core/src/encrypt/plain_message_public_key.rs
@@ -8,8 +8,8 @@ use crate::{
     random::RngSingleton,
 };
 use alloc::vec::Vec;
-use chacha20poly1305::{aead::Payload, XNonce};
 use crypto_box::{aead::Aead, ChaChaBox};
+use crypto_secretbox::{aead::Payload, AeadCore, Nonce as XNonce};
 
 use super::encrypted_message::EncryptedMessage;
 
@@ -81,6 +81,6 @@ pub trait PlainMessagePublicKeyCore {
     /// Generate random nonce which is large enough (24-byte) to rarely conflict.
     fn generate_nonce() -> XNonce {
         let mut rng = Self::R::instance();
-        crypto_box::generate_nonce(rng.deref_mut())
+        crypto_box::ChaChaBox::generate_nonce(rng.deref_mut())
     }
 }

--- a/serde-encrypt-core/src/encrypt/plain_message_shared_key.rs
+++ b/serde-encrypt-core/src/encrypt/plain_message_shared_key.rs
@@ -9,8 +9,8 @@ pub use shared_key_deterministic_core::PlainMessageSharedKeyDeterministicCore;
 use super::encrypted_message::EncryptedMessage;
 use crate::{error::Error, key::as_shared_key::AsSharedKey};
 use alloc::{format, vec::Vec};
-use chacha20poly1305::{XChaCha20Poly1305, XNonce};
-use crypto_box::aead::{Aead, NewAead};
+use crypto_box::aead::Aead;
+use crypto_secretbox::{KeyInit, Nonce as XNonce, XChaCha20Poly1305};
 
 /// Encrypt into EncryptedMessage
 fn encrypt<S>(

--- a/serde-encrypt-core/src/encrypt/plain_message_shared_key/shared_key_core.rs
+++ b/serde-encrypt-core/src/encrypt/plain_message_shared_key/shared_key_core.rs
@@ -4,8 +4,8 @@ use crate::encrypt::encrypted_message::EncryptedMessage;
 use crate::random::RngSingleton;
 use crate::{error::Error, key::as_shared_key::AsSharedKey};
 use alloc::vec::Vec;
-use chacha20poly1305::XNonce;
 use core::ops::DerefMut;
+use crypto_secretbox::{AeadCore, Nonce as XNonce};
 
 use super::{decrypt, encrypt};
 
@@ -47,6 +47,6 @@ pub trait PlainMessageSharedKeyCore {
     /// Generate random nonce which is large enough (24-byte) to rarely conflict.
     fn generate_nonce() -> XNonce {
         let mut rng = Self::R::instance();
-        crypto_box::generate_nonce(rng.deref_mut())
+        crypto_box::ChaChaBox::generate_nonce(rng.deref_mut())
     }
 }

--- a/serde-encrypt-core/src/encrypt/plain_message_shared_key/shared_key_deterministic_core.rs
+++ b/serde-encrypt-core/src/encrypt/plain_message_shared_key/shared_key_deterministic_core.rs
@@ -4,7 +4,7 @@ use crate::{
     encrypt::encrypted_message::EncryptedMessage, error::Error, key::as_shared_key::AsSharedKey,
 };
 use alloc::vec::Vec;
-use chacha20poly1305::XNonce;
+use crypto_secretbox::Nonce as XNonce;
 
 use super::{decrypt, encrypt};
 

--- a/serde-encrypt-core/src/key/as_shared_key.rs
+++ b/serde-encrypt-core/src/key/as_shared_key.rs
@@ -1,8 +1,8 @@
 //! Keys for common key cryptosystem.
 
 use crate::random::RngSingleton;
-use chacha20poly1305::Key as ChaChaKey;
 use core::{convert::TryInto, ops::DerefMut};
+use crypto_secretbox::Key as ChaChaKey;
 use rand::RngCore;
 
 /// 32-byte key shared among sender and receiver secretly.

--- a/serde-encrypt/Cargo.toml
+++ b/serde-encrypt/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.7.0"
 serde-encrypt-core = {version = "0.7.0", path = "../serde-encrypt-core", default-features = false}
 
 bincode = {version = "1.3", optional = true}
-postcard = {version = "0.7", default-features = false, features = ["alloc"]}
+postcard = {version = "1.1.1", default-features = false, features = ["alloc"]}
 serde = {version = "1.0", default-features = false}
 serde_cbor = {version = "0.11", default-features = false, features = ["alloc"]}
 

--- a/serde-encrypt/src/shared_key.rs
+++ b/serde-encrypt/src/shared_key.rs
@@ -2,8 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{AsSharedKey, random::RngSingletonImpl};
 use crate::traits::SerdeEncryptPublicKey;
+use crate::{random::RngSingletonImpl, AsSharedKey};
 
 /// 32-byte key shared among sender and receiver secretly.
 ///
@@ -52,13 +52,15 @@ cfg_if::cfg_if! {
 
 #[cfg(test)]
 mod test {
-    use std::convert::TryInto;
     use super::*;
+    use std::convert::TryInto;
 
     #[test]
     fn build_sharedkey_from_array() {
-        const STATIC_ARRAY: [u8; 32] = [1, 1, 4, 5, 1, 4,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        const STATIC_ARRAY: [u8; 32] = [
+            1, 1, 4, 5, 1, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0,
+        ];
 
         let runtime_array: [u8; 32] = Vec::from(STATIC_ARRAY).try_into().unwrap();
 


### PR DESCRIPTION
serde_cbor is still outdated, I recommend using minicbor as it keeps serde compatibility. However, I didnt manage to fix the test that it breaks. Will do in another PR https://rustsec.org/advisories/RUSTSEC-2021-0127 

@laysakura 